### PR TITLE
optimization: don't enlarge images

### DIFF
--- a/src/image-optimizer-lambda.ts
+++ b/src/image-optimizer-lambda.ts
@@ -52,7 +52,7 @@ export const handler = async (event: APIGatewayProxyEventV2) => {
   }
 
   const optimizedImageBuffer = await sharp(image.byteArray)
-    .resize({ width })
+    .resize({ width, withoutEnlargement: true })
     .toFormat(format)
     .toBuffer();
 


### PR DESCRIPTION
Currently a 280x280 pixel image gets enlarged if the proposed width is something larger. This makes sure images don't get unnecessarily resized.